### PR TITLE
adjust when to run github actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: '20 5 * * 1'
   push:
-  pull_request:
 
 env:
   REGISTRY: docker.io
@@ -26,7 +25,7 @@ jobs:
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/pull')
+        if: secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN && !startsWith(github.ref, 'refs/pull')
         uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
         with:
           registry: ${{ env.REGISTRY }}
@@ -48,6 +47,6 @@ jobs:
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/pull') }}
+          push: ${{ secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN && !startsWith(github.ref, 'refs/pull') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
don't run on pull request events, running on push is enough
don't try to login/push if secrets not available